### PR TITLE
Pull normNoise and normNoise32; Eval2 and Eval3 implemented

### DIFF
--- a/opensimplex_normalized.go
+++ b/opensimplex_normalized.go
@@ -12,6 +12,9 @@ const (
 
 	normMin3   = 0.944824004155
 	normScale3 = 0.5291990849667171
+
+	normMin4   = 1.034
+	normScale4 = 0.48355899419729204
 )
 
 type normNoise struct {
@@ -33,9 +36,11 @@ func (s *normNoise) Eval3(x, y, z float64) float64 {
 	return (r + normMin3) * normScale3
 }
 
-// TODO: Find normalization constants for Eval4 and write this function.
+// Eval4 returns a random noise value in four dimensions
+// in the range [0, 1).
 func (s *normNoise) Eval4(x, y, z, t float64) float64 {
-	return 0.5
+	r := s.base.Eval4(x, y, z, t)
+	return (r + normMin4) * normScale4
 }
 
 type normNoise32 struct {
@@ -75,7 +80,18 @@ func (s *normNoise32) Eval3(x, y, z float32) float32 {
 	}
 }
 
-// TODO: Find normalization constants for Eval4 and write this function.
+// Eval4 returns a random noise value in four dimensions
+// in the range [0, 1).
 func (s *normNoise32) Eval4(x, y, z, t float32) float32 {
-	return 0.5
+	r := s.base.Eval4(float64(x), float64(y), float64(z), float64(t))
+	norm64 := (r + normMin4) * normScale4
+	norm32 := float32(norm64)
+
+	// Unlike Eval2, have not actually tested whether a
+	// simple float32 cast will produce 1.0, but it seems likely.
+	if norm32 >= 1.0 {
+		return float32(0.999999)
+	} else {
+		return norm32
+	}
 }

--- a/opensimplex_normalized.go
+++ b/opensimplex_normalized.go
@@ -1,0 +1,64 @@
+package opensimplex
+
+const (
+	// The normMin and normScale constants are used
+	// in the formula for normalizing the raw output
+	// of the OpenSimplex algorithm. They were
+	// derived from empirical observations of the
+	// range of raw values. They work on the approximate
+	// (-0.866, 0.866) range produced by Eval2.
+	// TODO: If the raw Eval3 or Eval4 functions produce a
+	// different range, they will require different constants to
+	// normalize.
+	normMin   = 0.864366441
+	normScale = 0.5784583670
+)
+
+// TODO: Implement Eval3 and Eval4 to satisfy Noise interface.
+type normNoise struct {
+	base noise
+}
+
+// Eval2 returns a random noise value in two dimensions
+// in the range [0, 1).
+func (s *normNoise) Eval2(x, y float64) float64 {
+	return norm(s.base.Eval2(x, y))
+}
+
+// TODO: Implement Eval3 and Eval4 to satisfy Noise32 interface.
+type normNoise32 struct {
+	base noise
+}
+
+// Eval2 returns a random noise value in two dimensions
+// in the range [0, 1).
+func (s *normNoise32) Eval2(x, y float32) float32 {
+	return norm32(s.base.Eval2(float64(x), float64(y)))
+}
+
+// norm accepts a value from one of the float64 Eval functions
+// and normalizes it to a value in the range [0, 1). Note: if
+// the desired end result is a float32, use norm32 instead,
+// which correctly handles the reduction in precision.
+func norm(n float64) float64 {
+	return (n + normMin) * normScale
+}
+
+// norm32 accepts a value from one of the float64 Eval functions and
+// normalizes it to a value in the range [0, 1). Because a
+// simple cast from a float64 to a float32 can cause issues
+// with precision, this function should be used instead of a
+// cast whenever a float32 is desired.
+func norm32(n float64) float32 {
+	norm64 := (n + normMin) * normScale
+	norm32 := float32(norm64)
+
+	// Empirical testing shows that a simple float32 cast
+	// from the normalized float64, as above, will sometimes
+	// produce a value of 1.0.
+	if norm32 >= 1.0 {
+		return float32(0.999999)
+	} else {
+		return norm32
+	}
+}

--- a/opensimplex_normalized.go
+++ b/opensimplex_normalized.go
@@ -14,7 +14,6 @@ const (
 	normScale3 = 0.5291990849667171
 )
 
-// TODO: Implement Eval3 and Eval4 to satisfy Noise interface.
 type normNoise struct {
 	base noise
 }
@@ -27,12 +26,18 @@ func (s *normNoise) Eval2(x, y float64) float64 {
 	return (r + normMin2) * normScale2
 }
 
+// Eval3 returns a random noise value in three dimensions
+// in the range [0, 1).
 func (s *normNoise) Eval3(x, y, z float64) float64 {
 	r := s.base.Eval3(x, y, z)
 	return (r + normMin3) * normScale3
 }
 
-// TODO: Implement Eval3 and Eval4 to satisfy Noise32 interface.
+// TODO: Find normalization constants for Eval4 and write this function.
+func (s *normNoise) Eval4(x, y, z, t float64) float64 {
+	return 0.5
+}
+
 type normNoise32 struct {
 	base noise
 }
@@ -52,4 +57,25 @@ func (s *normNoise32) Eval2(x, y float32) float32 {
 	} else {
 		return norm32
 	}
+}
+
+// Eval3 returns a random noise value in three dimensions
+// in the range [0, 1).
+func (s *normNoise32) Eval3(x, y, z float32) float32 {
+	r := s.base.Eval3(float64(x), float64(y), float64(z))
+	norm64 := (r + normMin3) * normScale3
+	norm32 := float32(norm64)
+
+	// Unlike Eval2, have not actually tested whether a
+	// simple float32 cast will produce 1.0, but it seems likely.
+	if norm32 >= 1.0 {
+		return float32(0.999999)
+	} else {
+		return norm32
+	}
+}
+
+// TODO: Find normalization constants for Eval4 and write this function.
+func (s *normNoise32) Eval4(x, y, z, t float32) float32 {
+	return 0.5
 }

--- a/opensimplex_normalized.go
+++ b/opensimplex_normalized.go
@@ -5,13 +5,13 @@ const (
 	// in the formula for normalizing the raw output
 	// of the OpenSimplex algorithm. They were
 	// derived from empirical observations of the
-	// range of raw values. They work on the approximate
-	// (-0.866, 0.866) range produced by Eval2.
-	// TODO: If the raw Eval3 or Eval4 functions produce a
-	// different range, they will require different constants to
-	// normalize.
-	normMin   = 0.864366441
-	normScale = 0.5784583670
+	// range of raw values. Different constants are
+	// required for each of Eval2, Eval3, and Eval4.
+	normMin2   = 0.864366441
+	normScale2 = 0.5784583670
+
+	normMin3   = 0.944824004155
+	normScale3 = 0.5291990849667171
 )
 
 // TODO: Implement Eval3 and Eval4 to satisfy Noise interface.
@@ -22,7 +22,14 @@ type normNoise struct {
 // Eval2 returns a random noise value in two dimensions
 // in the range [0, 1).
 func (s *normNoise) Eval2(x, y float64) float64 {
-	return norm(s.base.Eval2(x, y))
+	//return norm2_64(s.base.Eval2(x, y))
+	r := s.base.Eval2(x, y)
+	return (r + normMin2) * normScale2
+}
+
+func (s *normNoise) Eval3(x, y, z float64) float64 {
+	r := s.base.Eval3(x, y, z)
+	return (r + normMin3) * normScale3
 }
 
 // TODO: Implement Eval3 and Eval4 to satisfy Noise32 interface.
@@ -33,24 +40,8 @@ type normNoise32 struct {
 // Eval2 returns a random noise value in two dimensions
 // in the range [0, 1).
 func (s *normNoise32) Eval2(x, y float32) float32 {
-	return norm32(s.base.Eval2(float64(x), float64(y)))
-}
-
-// norm accepts a value from one of the float64 Eval functions
-// and normalizes it to a value in the range [0, 1). Note: if
-// the desired end result is a float32, use norm32 instead,
-// which correctly handles the reduction in precision.
-func norm(n float64) float64 {
-	return (n + normMin) * normScale
-}
-
-// norm32 accepts a value from one of the float64 Eval functions and
-// normalizes it to a value in the range [0, 1). Because a
-// simple cast from a float64 to a float32 can cause issues
-// with precision, this function should be used instead of a
-// cast whenever a float32 is desired.
-func norm32(n float64) float32 {
-	norm64 := (n + normMin) * normScale
+	r := s.base.Eval2(float64(x), float64(y))
+	norm64 := (r + normMin2) * normScale2
 	norm32 := float32(norm64)
 
 	// Empirical testing shows that a simple float32 cast


### PR DESCRIPTION
New types `normNoise` and `normNoise32` satisfy the `Noise` and `Noise32` interfaces. `Eval2` and `Eval3` produce normalized values in the range [0, 1), as discussed in #2.

`Eval4` is stubbed in to fulfill the interfaces, but not implemented. Finding the normalization constants involves running a large sample of the raw `Eval4`, but this is much slower than the others, and so is proving difficult. I continue to work on it.

No int-related normalizations have been provided, based on the theory that a normalized `float32` can be accurately multiplied to produce a desired integer range. I'm not 100% sure of this yet so will perform further testing. If necessary, explicit int normalizations will be easy to provide. (The drawback of not having these is that it relies on the user to use the normalized `float32` but not the `float64`, since I'm pretty sure the latter might produce the closed range [0, max] instead of [0, max).