### PR TITLE
Fix module path

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,1 +1,1 @@
-module github.com/ojrac/opensimplex
+module github.com/ojrac/opensimplex-go


### PR DESCRIPTION
A typo in go.mod prevents `go get` from updating dependencies:
```
go: github.com/ojrac/opensimplex-go@v1.0.0: parsing go.mod: unexpected module path "github.com/ojrac/opensimplex"
```